### PR TITLE
don't build docs every time

### DIFF
--- a/CMake_core.cmake
+++ b/CMake_core.cmake
@@ -168,7 +168,7 @@ if(TARGET Doxygen::doxygen)
     configure_file(${DOXYGEN_IN} ${DOXYGEN_OUT} @ONLY)
 
     doxygen_add_docs(doc_doxygen ${DOXYGEN_OUT}
-        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/extern/fwcore/doc COMMENT "Generating API documentation with Doxygen" VERBATIM)
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/extern/fwcore/doc COMMENT "Generating API documentation with Doxygen")
     ## doxygen_add_docs(VISCOMCoreDoc extern/fwcore/src)
 endif()
 

--- a/CMake_core.cmake
+++ b/CMake_core.cmake
@@ -167,7 +167,7 @@ if(TARGET Doxygen::doxygen)
     set(DOXYGEN_OUT ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
     configure_file(${DOXYGEN_IN} ${DOXYGEN_OUT} @ONLY)
 
-    add_custom_target(doc_doxygen ALL COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_OUT}
+    doxygen_add_docs(doc_doxygen ${DOXYGEN_OUT}
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/extern/fwcore/doc COMMENT "Generating API documentation with Doxygen" VERBATIM)
     ## doxygen_add_docs(VISCOMCoreDoc extern/fwcore/src)
 endif()


### PR DESCRIPTION
`add_cutstom_target` is executed unconditionally, use target `doc_doxygen` to generate config